### PR TITLE
fix: unicode on exactly index 7 should not panic

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -25,7 +25,7 @@ impl<'a, T: DeserializeParams<'a>> Uri<'a, bitcoin::address::NetworkUnchecked, T
             return Err(Error::Uri(UriError(UriErrorInner::TooShort)));
         }
 
-        if !string[..SCHEME.len()].eq_ignore_ascii_case(SCHEME) {
+        if !string.get(..SCHEME.len()).is_some_and(|s| s.eq_ignore_ascii_case(SCHEME)) {
             return Err(Error::Uri(UriError(UriErrorInner::InvalidScheme)));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,4 +427,11 @@ mod tests {
         assert!(uri.label.is_none());
         assert!(uri.message.is_none());
     }
+
+    #[test]
+    fn bad_unicode_scheme() {
+        let input = "bitcoinö:1andreas3batLhQa2FawWjeyjCqyBzypd";
+        let uri = input.parse::<Uri<'_, _>>();
+        assert!(uri.is_err());
+    }
 }


### PR DESCRIPTION
> ### Problem
> 
> A unicode character on exactly the right place (where the previous code used to split the string) would cause a panic.
> ### Fix
> 
> Treat the string as unicode in order to compare the scheme, turning the panic into error.

Thank you @lsunsi for opening the original PR

https://github.com/Kixunil/bip21/pull/25