### PR TITLE
Replace is_some_and with map_or for MSRV

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -25,7 +25,7 @@ impl<'a, T: DeserializeParams<'a>> Uri<'a, bitcoin::address::NetworkUnchecked, T
             return Err(Error::Uri(UriError(UriErrorInner::TooShort)));
         }
 
-        if !string.get(..SCHEME.len()).is_some_and(|s| s.eq_ignore_ascii_case(SCHEME)) {
+        if !string.get(..SCHEME.len()).map_or(false, |s| s.eq_ignore_ascii_case(SCHEME)) {
             return Err(Error::Uri(UriError(UriErrorInner::InvalidScheme)));
         }
 


### PR DESCRIPTION
is_some_and is stable only in Rust 1.70.0 and greater.

- map_or(false, |s| s.eq_ignore_ascii_case(SCHEME)):
  - This method is used to handle the Option returned by get().
  - If get() returns None (i.e., the string is too short), map_or() returns false.
  - If get() returns Some(s), it applies the closure |s| s.eq_ignore_ascii_case(SCHEME).
    - This closure checks if the substring s is equal to SCHEME, ignoring ASCII case differences.
    - If they are equal, it returns true; otherwise, it returns false.